### PR TITLE
Add salary calculation tests

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+# Makes the api directory a package for imports in tests

--- a/tests/test_salary_calculations.py
+++ b/tests/test_salary_calculations.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from api.main import calculate_tax_details, calculate_gross_from_net
+
+
+def test_calculate_tax_details_example():
+    result = calculate_tax_details(100000)
+    assert result["salaire_net"] == 92400
+    assert result["total_prelevements"] == result["total_cotisations"] + result["total_impot"]
+
+
+def test_calculate_gross_from_net_example():
+    desired_net = 92400
+    result = calculate_gross_from_net(desired_net)
+    assert abs(result["salaire_brut_requis"] - 100000) < 1000
+    assert result["total_prelevements"] == result["total_cotisations"] + result["total_impot"]
+    net_from_gross = calculate_tax_details(result["salaire_brut_requis"])["salaire_net"]
+    assert net_from_gross == pytest.approx(desired_net, abs=500)


### PR DESCRIPTION
## Summary
- add package marker for api to enable direct imports in tests
- test calculate_tax_details and calculate_gross_from_net for representative salary conversion and totals

## Testing
- `pytest tests/test_salary_calculations.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e2ea058c832a9e75d31384c43cc5